### PR TITLE
@gib - Remove the image url protocol replace from the Image mixin

### DIFF
--- a/lib/image.coffee
+++ b/lib/image.coffee
@@ -11,6 +11,6 @@ module.exports =
 
   imageUrl: (version = @defaultImageVersion()) ->
     if @hasImage version
-      @get('image_url').replace(':version', version).replace('http://', '//')
+      @get('image_url').replace(':version', version)
     else
       @missingImageUrl()

--- a/test/image.coffee
+++ b/test/image.coffee
@@ -28,10 +28,6 @@ describe 'Image Mixin', ->
     it 'returns the first image version by default', ->
       @model.imageUrl().should.equal '/bitty/large_square'
 
-    it 'returns a http(s) agnostic url', ->
-      @model.set image_url: 'http://foo/bar.jpg'
-      @model.imageUrl().should.equal '//foo/bar.jpg'
-
     describe 'with a round image', ->
       beforeEach ->
         @model.set
@@ -39,7 +35,7 @@ describe 'Image Mixin', ->
           image_url: 'http://stazic1.artsy.net/additional_images/42/:version.jpg'
 
       it 'returns an image url', ->
-        @model.imageUrl('round').should.equal '//stazic1.artsy.net/additional_images/42/round.jpg'
+        @model.imageUrl('round').should.equal 'http://stazic1.artsy.net/additional_images/42/round.jpg'
 
       it "returns missing image for a version that doesn't exist", ->
         @model.imageUrl('square').should.equal '/images/missing_image.png'


### PR DESCRIPTION
I guess cloudfront doesn't support this presently. We need another https solution.
