### PR TITLE
@dzucconi - Defensive defaultImageVersion no longer assumes image versions exist

### DIFF
--- a/lib/image.coffee
+++ b/lib/image.coffee
@@ -2,7 +2,11 @@ _   = require 'underscore'
 
 module.exports = (secureImagesUrl, imagesUrlPrefix='http://static%d.artsy.net') ->
 
-  defaultImageVersion: -> (@get('image_versions') or @get('versions'))[0]
+  defaultImageVersion: ->
+    if @has 'image_versions' or @has 'versions'
+      (@get('image_versions') or @get('versions'))[0]
+    else
+      null
 
   missingImageUrl: -> "/images/missing_image.png"
 

--- a/test/image.coffee
+++ b/test/image.coffee
@@ -67,3 +67,9 @@ describe 'Image Mixin', ->
 
       it 'returns the first image version by default', ->
         @model.imageUrl().should.equal 'https://ssl.artsy.net/bitty/large_square'
+
+    describe '#hasImage', ->
+
+      it 'returns false if there are no image versions', ->
+        @model.set 'image_versions', null
+        @model.hasImage().should.be.false


### PR DESCRIPTION
`hasImage` was using the `defaultImageVersion` result as a default param if none was passed (I added this). `defaultImageVersion` was assuming that there was a `versions` or `image_versions` array to check. The update checks that they exist first.
