### PR TITLE
@craigspaeth - `fetchUntilEnd` now respects the page data option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ artworks.fetchUntilEnd success: ->
   # Phew... I have all the artworks from Artsy
 ````
 
+It respects data params like page (if you fetch page 1 on the server and `fetchUntil` end on the client for example)
+````coffeescript
+# I already rendered page 1 from a `fetch`...
+artworks.fetchUntilEnd 
+  data:
+    page: 2
+    size: 20
+  success: ->
+    # I now have artwork 21 - the end
+````
+
 ### fetchSetItemsByKey(key, options)
 
 Fetches a set by key and populates the collection with the first result.

--- a/lib/fetch.coffee
+++ b/lib/fetch.coffee
@@ -25,6 +25,8 @@ module.exports = (artsyUrl) ->
     key = "fetch-until-end:#{JSON.stringify(options)}"
     success = =>
       page = 0
+      if options.data and options.data.page
+        page = options.data.page - 1
       opts = _.clone(options)
       fetchPage = =>
         @fetch _.extend opts,

--- a/test/fetch.coffee
+++ b/test/fetch.coffee
@@ -1,7 +1,7 @@
 sinon = require 'sinon'
 _ = require 'underscore'
 Backbone = require 'backbone'
-Fetch = require '../lib/fetch'
+Fetch = require '../lib/fetch.coffee'
 
 class Collection extends Backbone.Collection
 
@@ -22,11 +22,21 @@ describe 'fetch until end mixin', ->
 
     it 'keeps fetching until the API returns no results', (done) ->
       @collection.fetchUntilEnd success: =>
-        @collection.length.should.equal 3
+        @collection.should.have.lengthOf 3
         done()
       Backbone.sync.args[0][2].success [{ foo: 'bar' }]
       Backbone.sync.args[0][2].success [{ foo: 'bar' }]
       Backbone.sync.args[0][2].success [{ foo: 'bar' }]
+      Backbone.sync.args[0][2].success []
+
+    it 'respects the starting page param passed in the options', (done) ->
+      @collection.fetchUntilEnd
+        data: { page: 5 }
+        success: =>
+          @collection.should.have.lengthOf 2
+          done()
+      Backbone.sync.args[0][2].data.page.should.equal 5
+      Backbone.sync.args[0][2].success [{ foo: 'bar1' }, {foo: 'bar2'}]
       Backbone.sync.args[0][2].success []
 
 describe 'fetch set items by key mixin', ->


### PR DESCRIPTION
I am fetching show artworks. I get page one on the server and want to `fetchUntilEnd` on the client starting with page 2.
