### PR TITLE
@craigspaeth: Allow markdown conversion to be configured to optionally allow HTML through

### DIFF
--- a/lib/markdown.coffee
+++ b/lib/markdown.coffee
@@ -1,12 +1,21 @@
-markdown = require('markdown').markdown
-
+_ = require 'underscore'
+marked = require 'marked'
+renderer = new marked.Renderer
 stripTags = (str) ->
   return '' unless str?
   String(str).replace(/<\/?[^>]+>/g, '')
 
 module.exports =
-  mdToHtml: (attr) ->
-    markdown.toHTML @get(attr) or ''
+  mdToHtml: (attr, options = {}) ->
+    marked.setOptions _.defaults options,
+      renderer: renderer
+      gfm: true
+      tables: true
+      breaks: true
+      pedantic: false
+      sanitize: true
+      smartypants: false
+    marked @get(attr) or ''
 
   mdToHtmlToText: (attr) ->
     stripTags(@mdToHtml attr)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "preinstall": "coffee -c lib"
   },
   "dependencies": {
-    "markdown": "*",
+    "marked": "*",
     "underscore": "*",
     "backbone": "*"
   },

--- a/test/markdown.coffee
+++ b/test/markdown.coffee
@@ -13,7 +13,7 @@ describe 'Dimensions Mixin', ->
   describe '#mdToHtml', ->
     it 'returns HTML from parsed markdown', ->
       @model.set foo: "**foo** *bar*"
-      @model.mdToHtml('foo').should.eql '<p><strong>foo</strong> <em>bar</em></p>'
+      @model.mdToHtml('foo').should.eql '<p><strong>foo</strong> <em>bar</em></p>\n'
 
     it 'is defensive about missing data', ->
       @model.set foo: null
@@ -22,7 +22,12 @@ describe 'Dimensions Mixin', ->
     it 'is defensive about XSS', ->
       @model.set foo: "<img src=<script> src='<img<script>alert(document.domain)//</p> 
 </script>"
-      @model.mdToHtml('foo').should.equal '<p>&lt;img src=&lt;script&gt; src=&#39;&lt;img&lt;script&gt;alert(document.domain)//&lt;/p&gt; &lt;/script&gt;</p>'
+      @model.mdToHtml('foo').should.equal '<p>&lt;img src=&lt;script&gt; src=&#39;&lt;img&lt;script&gt;alert(document.domain)//&lt;/p&gt; &lt;/script&gt;</p>\n'
+
+    it 'is configurable to allow HTML through desireable', ->
+      @model.set foo: '<iframe src="https://mapsengine.google.com/map/u/0/embed?mid=zJZQ9AwtKFhA.kxtTsvo5bMR4" width="1100" height="733"></iframe>'
+      @model.mdToHtml('foo').should.equal '<p>&lt;iframe src=&quot;https://mapsengine.google.com/map/u/0/embed?mid=zJZQ9AwtKFhA.kxtTsvo5bMR4&quot; width=&quot;1100&quot; height=&quot;733&quot;&gt;&lt;/iframe&gt;</p>\n'
+      @model.mdToHtml('foo', sanitize: false).should.equal '<iframe src="https://mapsengine.google.com/map/u/0/embed?mid=zJZQ9AwtKFhA.kxtTsvo5bMR4" width="1100" height="733"></iframe>'
 
   describe '#htmlToText', ->
     it 'handles null input', ->


### PR DESCRIPTION
So we apparently _do_ have a need for allowing HTML input by trusted sources. This swaps out the Markdown parser... again. markdown.js doesn't let you configure it to allow HTML through.  [marked](https://github.com/chjj/marked) does (+ it's alot faster, which is nice)

So this swaps em out and lets us configure the field now: `@model.mdToHtml('foo', sanitize: false)`
