### PR TITLE
@dzucconi - adds stringify ability to fetchUntilEndInParallel

### DIFF
--- a/lib/fetch.coffee
+++ b/lib/fetch.coffee
@@ -66,7 +66,14 @@ module.exports.methods =
 
     { success, error } = options # Pull out original success and error callbacks
 
+    if typeof options.data is 'string' and options.stringify
+      options.data = Qs.parse options.data
+
+    { size } = options.data = _.defaults (options.data or {}), total_count: 1, size: 10
+
     options.remove = false
+
+    options.data = "#{Qs.stringify(options.data, {indices: false})}" if options.stringify
 
     options.error = =>
       dfd.reject arguments...
@@ -86,6 +93,10 @@ module.exports.methods =
         dfd.resolve this
         success? this
       else
+
+        if typeof options.data is 'string' and options.stringify
+          options.data = Qs.parse options.data
+
         remaining = Math.ceil(total / size) - 1
 
         Q.allSettled(_.times(remaining, (n) =>

--- a/lib/fetch.coffee
+++ b/lib/fetch.coffee
@@ -66,9 +66,6 @@ module.exports.methods =
 
     { success, error } = options # Pull out original success and error callbacks
 
-    if typeof options.data is 'string' and options.stringify
-      options.data = Qs.parse options.data
-
     { size } = options.data = _.defaults (options.data or {}), total_count: 1, size: 10
 
     options.remove = false

--- a/package.json
+++ b/package.json
@@ -32,13 +32,16 @@
     "marked": "*",
     "underscore": "*",
     "backbone": "*",
-    "q": "^1.1.2"
+    "q": "^1.1.2",
+    "qs" : "*"
   },
   "devDependencies": {
     "antigravity": "git+ssh://git@github.com:artsy/antigravity.git",
     "coffee-script": "*",
     "mocha": "*",
     "should": "*",
-    "sinon": "*"
+    "sinon": "*",
+    "q" : "*",
+    "qs" : "*"
   }
 }

--- a/test/fetch.coffee
+++ b/test/fetch.coffee
@@ -174,7 +174,7 @@ describe 'fetch until end in parallel mixin', ->
     it 'supports the each callback' # todo
 
     it 'accepts a string as options.data', ->
-      @collection.fetchUntilEndInParallel(url: 'http://foo.bar/baz', data: "type=CoolType&type=DumbType&size=12", stringify: true)
+      @collection.fetchUntilEndInParallel(url: 'http://foo.bar/baz', data: {type: ['CoolType', 'DumbType'], size: 12}, stringify: true)
       Backbone.sync.args[0][2].res = headers: 'x-total-count': 25
       Backbone.sync.args[0][2].success([])
       _.map(Backbone.sync.args, (args) -> args[2].url).should.eql [

--- a/test/fetch.coffee
+++ b/test/fetch.coffee
@@ -172,3 +172,18 @@ describe 'fetch until end in parallel mixin', ->
     it 'supports the error callback'
 
     it 'supports the each callback' # todo
+
+    it 'accepts a string as options.data', ->
+      @collection.fetchUntilEndInParallel(url: 'http://foo.bar/baz', data: "type=CoolType&type=DumbType&size=12", stringify: true)
+      Backbone.sync.args[0][2].res = headers: 'x-total-count': 25
+      Backbone.sync.args[0][2].success([])
+      _.map(Backbone.sync.args, (args) -> args[2].url).should.eql [
+        'http://foo.bar/baz'
+        'http://foo.bar/baz'
+        'http://foo.bar/baz'
+      ]
+      _.map(Backbone.sync.args, (args) -> args[2].data).should.eql [
+        'type=CoolType&type=DumbType&size=12'
+        'type=CoolType&type=DumbType&size=12&page=2'
+        'type=CoolType&type=DumbType&size=12&page=3'
+      ]

--- a/test/fetch.coffee
+++ b/test/fetch.coffee
@@ -183,7 +183,7 @@ describe 'fetch until end in parallel mixin', ->
         'http://foo.bar/baz'
       ]
       _.map(Backbone.sync.args, (args) -> args[2].data).should.eql [
-        'type=CoolType&type=DumbType&size=12'
+        'type=CoolType&type=DumbType&size=12&total_count=1'
         'type=CoolType&type=DumbType&size=12&page=2'
         'type=CoolType&type=DumbType&size=12&page=3'
       ]


### PR DESCRIPTION
Definitely open to suggestions here on how to make this better! 

This allows data with array params to be passed without converting them to arrays with indices.

fetchUntilEndInParallel now:
- takes `stringify` as an option
- if `stringify: true` is passed the data object gets converted into a string when the request is made