### PR TITLE
@dzucconi => do not sanitize when converting to plain text

### DIFF
--- a/lib/markdown.coffee
+++ b/lib/markdown.coffee
@@ -18,7 +18,7 @@ module.exports =
     marked @get(attr) or ''
 
   mdToHtmlToText: (attr) ->
-    stripTags(@mdToHtml attr)
+    stripTags(@mdToHtml attr, { sanitize: false })
 
   htmlToText: (attr) ->
     stripTags(@get attr)

--- a/test/markdown.coffee
+++ b/test/markdown.coffee
@@ -29,6 +29,15 @@ describe 'Dimensions Mixin', ->
       @model.mdToHtml('foo').should.equal '<p>&lt;iframe src=&quot;https://mapsengine.google.com/map/u/0/embed?mid=zJZQ9AwtKFhA.kxtTsvo5bMR4&quot; width=&quot;1100&quot; height=&quot;733&quot;&gt;&lt;/iframe&gt;</p>\n'
       @model.mdToHtml('foo', sanitize: false).should.equal '<iframe src="https://mapsengine.google.com/map/u/0/embed?mid=zJZQ9AwtKFhA.kxtTsvo5bMR4" width="1100" height="733"></iframe>'
 
+  describe '#mdToHtmlToText', ->
+    it 'strips markdown-generated HTML tags', ->
+      @model.set foo: '*bold text*'
+      @model.mdToHtmlToText('foo').trim().should.equal 'bold text'
+
+    it 'strips literal HTML tags', ->
+      @model.set foo: '<b>bold text</b>'
+      @model.mdToHtmlToText('foo').trim().should.equal 'bold text'
+
   describe '#htmlToText', ->
     it 'handles null input', ->
       @model.set foo: null


### PR DESCRIPTION
cc @craigspaeth 

Prospective change -- not completely sure, but it seems like we never want to sanitize if we're going to convert to directly to text. Otherwise we'll end up with entities in plain text, which doesn't seem useful. 